### PR TITLE
Changed site-maven-plugin version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,15 +1,5 @@
-machine:
-  ruby:
-    version: rbx-2.2.6
-
-general:
-   artifacts:
-     - $CIRCLE_TEST_REPORTS
-     - target
-     
 test:
   override:
-    - mvn clean install
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,4 @@
 test:
-  override:
-  post:
-    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-    - find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+ post:
+   - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+   - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  ruby:
+    version: rbx-2.2.6
+
+general:
+   artifacts:
+     - $CIRCLE_TEST_REPORTS
+     - target
+     
+test:
+  override:
+    - mvn clean install
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.11</version>
+				<version>0.9</version>
 				<configuration>
 					<message>Creating site for ${project.version}</message>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.9</version>
+				<version>0.10</version>
 				<configuration>
 					<message>Creating site for ${project.version}</message>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.11</version>
+				<version>0.10</version>
 				<configuration>
 					<message>Creating site for ${project.version}</message>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.12</version>
+				<version>0.9</version>
 				<configuration>
 					<message>Creating site for ${project.version}</message>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.10</version>
+				<version>0.11</version>
 				<configuration>
 					<message>Creating site for ${project.version}</message>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.10</version>
+				<version>0.9</version>
 				<configuration>
 					<message>Creating site for ${project.version}</message>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.9</version>
+				<version>0.11</version>
 				<configuration>
 					<message>Creating site for ${project.version}</message>
 				</configuration>


### PR DESCRIPTION
It appears that version.12 has a problem. One of the dependencies is missing
It leads to the error that prevent building the project correctly:
Downloading: https://repo.maven.apache.org/maven2/org/eclipse/mylyn/github/org.eclipse.egit.github.core/3.1.0.201310021548-r/org.eclipse.egit.github.core-3.1.0.201310021548-r.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.809 s
[INFO] Finished at: 2017-04-09T23:21:20+00:00
[INFO] Final Memory: 31M/1452M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:2.8:resolve-plugins (resolve-plugins) on project podam: Nested: Could not find artifact org.eclipse.mylyn.github:org.eclipse.egit.github.core:jar:3.1.0.201310021548-r in central (https://repo.maven.apache.org/maven2)